### PR TITLE
Optimize runtime for PNG and JPEG

### DIFF
--- a/optimize.rb
+++ b/optimize.rb
@@ -29,10 +29,10 @@ ignore = ENV["IGNORE"].split(File::PATH_SEPARATOR).flat_map { |path| expand(path
 
 # Setup ImageOptim options.
 image_optim = ImageOptim.new(
-  :advpng => {
-    :level => 3
-  },
-  :pngout => false,
+  :advpng => false, # redundant with oxipng
+  :pngcrush => false, # redundant with oxipng
+  :pngout => false, # redundant with oxipng
+  :optipng => false, # redundant with oxipng
   :svgo => {
     :enable_plugins => %w[
         cleanupAttrs cleanupListOfValues cleanupNumericValues convertColors convertStyleToAttrs

--- a/optimize.rb
+++ b/optimize.rb
@@ -33,6 +33,8 @@ image_optim = ImageOptim.new(
   :pngcrush => false, # redundant with oxipng
   :pngout => false, # redundant with oxipng
   :optipng => false, # redundant with oxipng
+  :jpegoptim => false, # redundant with jpegrecompress
+  :jpegtran => false, # redundant with jpegrecompress
   :svgo => {
     :enable_plugins => %w[
         cleanupAttrs cleanupListOfValues cleanupNumericValues convertColors convertStyleToAttrs


### PR DESCRIPTION
Disable optimizers that are unlikely to be useful. Prefers oxipng (recently introduced in image_optim) for PNG, and jpeg-recompress for JPEG.