### PR TITLE
Update deprecated set-output usage

### DIFF
--- a/optimize.rb
+++ b/optimize.rb
@@ -79,7 +79,7 @@ if results.size > 2
   # Escape %, \n, and \r.
   # Ref: https://github.community/t/set-output-truncates-multiline-strings/16852/3
   summary.gsub!(/[%\n\r]/, "%" => "%25", "\n" => "%0A", "\r" => "%0D")
-  puts "::set-output name=summary::#{summary}"
+  puts "echo ':name=summary::#{summary}' >> $GITHUB_OUTPUT"
 else
   puts "Nothing to optimize"
 end

--- a/optimize.rb
+++ b/optimize.rb
@@ -79,7 +79,11 @@ if results.size > 2
   # Escape %, \n, and \r.
   # Ref: https://github.community/t/set-output-truncates-multiline-strings/16852/3
   summary.gsub!(/[%\n\r]/, "%" => "%25", "\n" => "%0A", "\r" => "%0D")
-  puts "echo ':name=summary::#{summary}' >> $GITHUB_OUTPUT"
+  output_file = ENV["GITHUB_OUTPUT"]
+  open(output_file, 'a') do |f|
+    f << "summary=#{summary}"
+  end
+
 else
   puts "Nothing to optimize"
 end


### PR DESCRIPTION
`set-output` is [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and will be disabled on May 31st.
